### PR TITLE
Fix ChromaDB sqlite3 version error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ chromadb==0.4.22
 chromadb-server>=0.1.0  # Server component for ChromaDB
 tiktoken==0.9.0
 sqlite-vss>=0.1.2  # Provides newer SQLite with vector search support
+pysqlite3-binary>=0.5.1  # Modern SQLite build required by ChromaDB
 
 # Web UI
 streamlit==1.45.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "pandas>=2.3.0",
         "docling>=2.36.1",
         "chromadb>=1.0.12",
+        "pysqlite3-binary>=0.5.1",
         "streamlit>=1.45.1",
     ],
     python_requires=">=3.8",

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,43 @@
+"""Site-wide customizations loaded automatically by Python.
+
+This file ensures **every** Python process in this virtual environment has
+access to a recent SQLite runtime, which some third-party libraries (e.g.
+ChromaDB) require.
+
+Python executes ``import site`` on startup and, as documented, `site`
+attempts to import ``sitecustomize`` if it exists on the import path.  By
+placing this module at the project root (which is included in
+``PYTHONPATH`` when our tooling runs) we guarantee that the monkey-patch
+below is performed *before* any regular user code – including CLI tools
+like ``chroma`` – touches ``sqlite3``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _patch_sqlite() -> None:
+    """Replace stdlib ``sqlite3`` with the modern `pysqlite3` build.
+
+    If the wheel is not available we silently skip – consumers will get the
+    system SQLite and may raise their own errors later.
+    """
+
+    try:
+        import pysqlite3 as _pysqlite3  # noqa: WPS433 – late import OK
+
+        # Any subsequent ``import sqlite3`` (direct or indirect) will now
+        # receive the upgraded module.
+        sys.modules["sqlite3"] = _pysqlite3  # type: ignore[assignment]
+    except ModuleNotFoundError:
+        # Fall back gracefully – the project’s requirements should install
+        # the wheel, but we don't crash if it is missing.
+        pass
+
+
+# Perform the patch as early as possible.
+_patch_sqlite()
+
+# Clean-up internal names (optional but keeps ``help()`` tidy).
+del _patch_sqlite

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,38 @@
 """
 Flash Report Generator package.
+
+This package loads a modern SQLite runtime (via the ``pysqlite3`` wheel)
+*before* anything else touches ``sqlite3``.  ChromaDB requires
+``sqlite3 >= 3.35`` and many Linux distributions ship an older build.
+
+If ``pysqlite3`` is available we monkey-patch the standard library
+module slot so that every subsequent ``import sqlite3`` (including those
+that take place deep inside ChromaDB) receives the newer implementation.
+
+This happens at ``import src`` time which means it will execute once
+and **very** early – well before the rest of our application (or
+third-party libraries) have a chance to import ``sqlite3`` on their own.
 """
 
+# ---------------------------------------------------------------------------
+# Ensure ChromaDB sees a recent SQLite version
+# ---------------------------------------------------------------------------
+
+try:
+    # The binary wheel bundles a recent SQLite (≥3.38).  We import it and
+    # then overwrite the ``sqlite3`` entry in ``sys.modules`` so that the
+    # standard library name resolves to this upgraded build everywhere.
+    import pysqlite3 as _pysqlite3  # noqa: WPS433  (third-party import alias)
+    import sys
+
+    sys.modules["sqlite3"] = _pysqlite3  # type: ignore[assignment]
+except ModuleNotFoundError:
+    # ``pysqlite3-binary`` isn't installed – fall back to the system
+    # sqlite3.  ChromaDB will raise a clear error later if it is too old.
+    pass
+
+
+# Package metadata
 __version__ = "0.1.0"
 __author__ = "Your Name"
 __license__ = "MIT" 


### PR DESCRIPTION
Resolve ChromaDB's SQLite version incompatibility by monkey-patching the `sqlite3` module with `pysqlite3-binary`.

Many systems ship with an older SQLite version than ChromaDB's requirement (>=3.35.0). This PR adds `pysqlite3-binary` (which bundles a modern SQLite) and ensures that all `sqlite3` imports, including those within ChromaDB, are redirected to this newer version at application startup.